### PR TITLE
Strip BOM from input before parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var ndjson = require('ndjson')
 var parseCsv = require('csv-parser')
 var pumpify = require('pumpify')
 var through2 = require('through2')
+var stripBomStream = require('strip-bom-stream')
 
 // ===================================================================
 
@@ -13,6 +14,7 @@ function csv2json (opts) {
   opts || (opts = {})
 
   return pumpify([
+    stripBomStream(),
     parseCsv({
       separator: opts.separator
     }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csv2json",
-  "version": "1.1.0",
+  "version": "1.1.0-1",
   "license": "ISC",
   "description": "Stream and CLI to convert CSV to JSON",
   "keywords": [
@@ -25,7 +25,8 @@
     "ndjson": "^1.4.1",
     "pump": "^1.0.0",
     "pumpify": "^1.3.3",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "strip-bom-stream": "^2.0.0"
   },
   "devDependencies": {
     "standard": "^8.2.0"


### PR DESCRIPTION
The Byte Order Mark (BOM) in a CSV file causes the csv-parser to misinterpret the first column in the header row. To reproduce, create a CSV file with a BOM at the beginning, and run it through csv2json. The first column header will come as a JSON property like this: "\"property\"".